### PR TITLE
Switch Travis CI to ubuntu:18.04 (bionic LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ os: linux
 
 language: generic
 
+services:
+ - docker
+
 install:
- - sudo apt-get install gprbuild gnat
+ - docker pull ubuntu:18.04
 
 script:
- - make all check
+ - docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:18.04
+
+RUN apt-get -qq update
+RUN apt-get install -y make gnat gprbuild
+
+RUN mkdir -p /src/
+WORKDIR /src/
+
+COPY . /src/
+
+RUN make all check


### PR DESCRIPTION
to use newer gprbuild. Ubuntu 18.04 provides 2017, while 16.04 has
only gprbuild 2014, which is buggy.